### PR TITLE
sc 29: Ability to make a holiday request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 
 .firebase
 secrets.json
+
+# general notes to help me pick up from where i left off
+dev-notes.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["authed"]
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "cross-env": "^7.0.3",
+    "date-fns": "^2.25.0",
     "firebase": "^9.0.2",
     "firebase-admin": "^9.11.1",
     "firebase-functions": "^3.15.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,20 @@
 import { ChakraProvider } from '@chakra-ui/react'
 import { AuthProvider } from '../src/provider/AuthProvider'
+import { RequestProvider } from '../src/provider/requestProvider'
+import { UserProvider } from '../src/provider/userProvider'
 import Layout from '../src/components/Layout'
 
 function MyApp({ Component, pageProps }) {
   return (
     <ChakraProvider>
       <AuthProvider>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
+        <RequestProvider>
+          <UserProvider>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </UserProvider>
+        </RequestProvider>
       </AuthProvider>
     </ChakraProvider>
   )

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,12 +1,13 @@
 import { withProtection } from '@Services/withProtection'
+import { useRequests } from '@Context/requestContext'
 
 const Dashboard = () => {
+  const { holidayRequests } = useRequests()
+
   return (
     <>
-      <div>
-        <h1>Dashboard</h1>
-        <a href="/holiday-request">Make a holiday request</a>
-      </div>
+      <div>{holidayRequests && <p>Holiday requests made</p>}</div>
+      <div>{!holidayRequests && <p>No Holiday requests made</p>}</div>
     </>
   )
 }

--- a/src/api/auth-api/index.ts
+++ b/src/api/auth-api/index.ts
@@ -15,6 +15,7 @@ export class AuthApi extends FirebaseApi {
     const { user } = await createUserWithEmailAndPassword(this.auth, email, password)
 
     this.user = user
+
     if (this.user) {
       await this.addFirestoreUser({ username, role: this.defaultSetupRole, email, firstName, lastName, squad })
     }

--- a/src/api/firestore-api/index.ts
+++ b/src/api/firestore-api/index.ts
@@ -1,0 +1,66 @@
+import { addBusinessDays } from 'date-fns'
+import { FirebaseApi } from '../firebase-api'
+import { collection, doc, query, where, setDoc, getDocs, getDoc } from 'firebase/firestore'
+import { DocumentData } from '@google-cloud/firestore'
+
+export interface SignupProps {
+  email: string
+  firstName: string
+  lastName: string
+  password: string
+  squad: string
+  username: string
+}
+
+export class FirestoreApi extends FirebaseApi {
+  public async postHolidayRequest({ fromDate, reason, authedUser, totalDays, totalHours }): Promise<void> {
+    const holidayCollectionRef = await collection(this.firestore, 'holidays')
+    const holidayRequestDocRef = doc(holidayCollectionRef)
+    const userCollection = await collection(this.firestore, 'users')
+    const userRef = await doc(userCollection, authedUser.uid)
+
+    await setDoc(holidayRequestDocRef, {
+      ...this.formatRequestDetails({ fromDate, totalDays, totalHours }),
+      user: userRef,
+      status: 'pending',
+      reason,
+    })
+  }
+
+  public async getAllHolidayRequests({ userId }): Promise<DocumentData[]> {
+    const holidayCollectionRef = await collection(this.firestore, 'holidays')
+    const userCollection = await collection(this.firestore, 'users')
+    const userRef = await doc(userCollection, userId)
+
+    const q = query(holidayCollectionRef, where('user', '==', userRef))
+    const querySnapshot = await getDocs(q)
+    const holidayRequests = await querySnapshot.docs.map((request) => request.data())
+
+    return holidayRequests
+  }
+
+  public async getUserDetails(userId): Promise<DocumentData> {
+    const userCollection = await collection(this.firestore, 'users')
+    const userRef = await doc(userCollection, userId)
+    const userDetails = await getDoc(userRef)
+
+    return userDetails.data()
+  }
+
+  private formatRequestDetails = ({ fromDate, totalDays, totalHours }) => {
+    const durationInHours = this.getTotalHours(totalDays, totalHours)
+    const toDate = addBusinessDays(fromDate, totalDays).toISOString()
+
+    return {
+      from: new Date(fromDate).toISOString(),
+      to: toDate,
+      duration: durationInHours,
+    }
+  }
+
+  private getTotalHours = (days, hours): number => {
+    const contractualHours = 7.5
+
+    return contractualHours * days + hours
+  }
+}

--- a/src/context/requestContext.tsx
+++ b/src/context/requestContext.tsx
@@ -1,0 +1,12 @@
+import { DocumentData } from '@firebase/firestore'
+import { createContext, useContext } from 'react'
+
+interface IHolidayRequests {
+  holidayRequests: DocumentData[] | null
+}
+
+export const requestContext = createContext<IHolidayRequests>({
+  holidayRequests: null,
+})
+
+export const useRequests = () => useContext(requestContext)

--- a/src/context/userDetailsContext.tsx
+++ b/src/context/userDetailsContext.tsx
@@ -1,0 +1,12 @@
+import { DocumentData } from '@firebase/firestore'
+import { createContext, useContext } from 'react'
+
+interface IHolidayRequests {
+  userDetails: DocumentData | null
+}
+
+export const userDetailsContext = createContext<IHolidayRequests>({
+  userDetails: null,
+})
+
+export const useUserDetails = () => useContext(userDetailsContext)

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -1,10 +1,15 @@
 import { useState, useEffect } from 'react'
 import { firebaseClient } from '@Firebase/firebaseClient'
 
+interface IAuthedUser {
+  uid: string
+  email: string
+}
+
 export default function useFirebaseAuth() {
   const { auth } = firebaseClient()
-  const [authedUser, setAuthedUser] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const [authedUser, setAuthedUser] = useState<IAuthedUser | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
 
   const authStateChanged = async (authState) => {
     if (!authState) {

--- a/src/provider/requestProvider.tsx
+++ b/src/provider/requestProvider.tsx
@@ -1,0 +1,24 @@
+import useFirebaseAuth from '@Hooks/useFirebaseAuth'
+import { requestContext } from '@Context/requestContext'
+import { FirestoreApi } from '@Firebase-api/firestore-api'
+import { useEffect, useState } from 'react'
+
+export function RequestProvider({ children }) {
+  const { Provider } = requestContext
+  const firestoreApi = new FirestoreApi()
+  const { authedUser } = useFirebaseAuth()
+  const [holidayRequests, setHolidayRequests] = useState(null)
+
+  useEffect(() => {
+    if (authedUser) {
+      firestoreApi
+        .getAllHolidayRequests({ userId: authedUser.uid })
+        .then((result) => {
+          setHolidayRequests(result)
+        })
+        .catch((err) => console.log(err))
+    }
+  }, [authedUser])
+
+  return <Provider value={{ holidayRequests }}>{children}</Provider>
+}

--- a/src/provider/userProvider.tsx
+++ b/src/provider/userProvider.tsx
@@ -1,0 +1,24 @@
+import useFirebaseAuth from '@Hooks/useFirebaseAuth'
+import { userDetailsContext } from '@Context/userDetailsContext'
+import { FirestoreApi } from '@Firebase-api/firestore-api'
+import { useEffect, useState } from 'react'
+
+export function UserProvider({ children }) {
+  const { Provider } = userDetailsContext
+  const firestoreApi = new FirestoreApi()
+  const { authedUser } = useFirebaseAuth()
+  const [userDetails, setUserDetails] = useState(null)
+
+  useEffect(() => {
+    if (authedUser) {
+      firestoreApi
+        .getUserDetails(authedUser.uid)
+        .then((result) => {
+          setUserDetails(result)
+        })
+        .catch((err) => console.log(err))
+    }
+  }, [authedUser])
+
+  return <Provider value={{ userDetails }}>{children}</Provider>
+}

--- a/src/utils/date-formatting.test.ts
+++ b/src/utils/date-formatting.test.ts
@@ -1,0 +1,24 @@
+import { dateRangeToHours } from './date-formatting'
+
+describe('#dateRangeToHours', () => {
+  const fromDate = new Date('Oct 25 2021 08:00:00')
+  const toDate = new Date('Nov 07 2021 12:00:00')
+
+  it('returns the number of business days for a given date range', () => {
+    expect(dateRangeToHours(fromDate, toDate)).toEqual(10)
+  })
+
+  it('returns the number of business days for a given date range', () => {
+    const fromDate = new Date('Oct 25 2021 08:00:00')
+    const toDate = new Date('Oct 26 2021 17:00:00')
+
+    expect(dateRangeToHours(fromDate, toDate)).toEqual(1)
+  })
+
+  it('returns the number of business days for a given date range', () => {
+    const fromDate = new Date('Oct 25 2021 08:00:00')
+    const toDate = new Date('Nov 01 2021 17:00:00')
+
+    expect(dateRangeToHours(fromDate, toDate)).toEqual(5)
+  })
+})

--- a/src/utils/date-formatting.ts
+++ b/src/utils/date-formatting.ts
@@ -1,0 +1,13 @@
+import { differenceInBusinessDays, format } from 'date-fns'
+
+export const dateRangeToHours = (from: Date, to: Date): number => {
+  const dateDuration = differenceInBusinessDays(to, from)
+
+  return dateDuration
+}
+
+export const getDayMonthYear = (date: string): string => {
+  const dayMonthYear = 'eeee io MMMM yyyy'
+
+  return format(new Date(date), dayMonthYear)
+}

--- a/tests/pages/dashboard.test.tsx
+++ b/tests/pages/dashboard.test.tsx
@@ -1,6 +1,9 @@
 import { render } from '@testing-library/react'
 import Dashboard from '@Pages/dashboard'
 
+let mockAuthedUser: string | null = '12345'
+let mockHolidayRequests = []
+
 jest.mock('next/router', () => ({
   useRouter() {
     return {
@@ -9,8 +12,6 @@ jest.mock('next/router', () => ({
   },
 }))
 
-let mockAuthedUser: string | null = '12345'
-
 jest.mock('@Context/AuthContext', () => ({
   useAuth: () => ({
     authedUser: mockAuthedUser,
@@ -18,21 +19,29 @@ jest.mock('@Context/AuthContext', () => ({
   }),
 }))
 
+jest.mock('@Context/requestContext', () => ({
+  useRequests: () => ({
+    holidayRequests: mockHolidayRequests,
+  }),
+}))
+
 describe('Dashboard', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    jest.clearAllMocks()
     mockAuthedUser = '12345'
   })
 
   it('renders the dashboard page when a user is logged in', () => {
     const { getByText } = render(<Dashboard />)
 
-    expect(getByText('Dashboard')).toBeInTheDocument()
+    expect(getByText('Holiday requests made')).toBeInTheDocument()
   })
 
   it('Does not render the dashboard page when a user has not logged in', () => {
     mockAuthedUser = null
+    mockHolidayRequests = null
     const { queryByText } = render(<Dashboard />)
 
-    expect(queryByText('Dashboard')).not.toBeInTheDocument()
+    expect(queryByText('No Holiday requests made')).not.toBeInTheDocument()
   })
 })

--- a/tests/pages/holiday-request.test.tsx
+++ b/tests/pages/holiday-request.test.tsx
@@ -1,15 +1,17 @@
-import { render } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import HolidayRequest from '@Pages/holiday-request'
-
-jest.mock('next/router', () => ({
-  useRouter() {
-    return {
-      replace: jest.fn(),
-    }
-  },
-}))
+import { useRouter } from 'next/router'
 
 let mockAuthedUser: string | null = '12345'
+const mockPostHolidayRequest = jest.fn()
+const mockedUseRouter = useRouter as jest.Mock
+
+jest.mock('next/router')
+jest.mock('@Firebase-api/firestore-api', () => ({
+  FirestoreApi: function () {
+    return { postHolidayRequest: mockPostHolidayRequest }
+  },
+}))
 
 jest.mock('@Context/AuthContext', () => ({
   useAuth: () => ({
@@ -18,9 +20,12 @@ jest.mock('@Context/AuthContext', () => ({
   }),
 }))
 
+const mockedRouterReplace = jest.fn()
 describe('HolidayRequest', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    jest.clearAllMocks()
     mockAuthedUser = '12345'
+    mockedUseRouter.mockImplementation(() => ({ route: '/holidayRequest', replace: mockedRouterReplace }))
   })
 
   it('renders the holiday request page when a user is logged in', () => {
@@ -29,10 +34,58 @@ describe('HolidayRequest', () => {
     expect(getByText('DeliveryHR')).toBeInTheDocument()
   })
 
-  it('Does not render the holiday request page when a user has not logged in', () => {
+  it('does not render the holiday request page when a user has not logged in', () => {
     mockAuthedUser = null
     const { queryByText } = render(<HolidayRequest />)
 
     expect(queryByText('DeliveryHR')).not.toBeInTheDocument()
+  })
+
+  it('renders the holiday request form', () => {
+    const { getByText } = render(<HolidayRequest />)
+
+    expect(getByText('Make a holiday request')).toBeInTheDocument()
+  })
+
+  describe('making a holiday request', () => {
+    it('calls the firestore post holiday request api with the correct holiday request information', () => {
+      const { getByLabelText, getByRole } = render(<HolidayRequest />)
+      const fromInput = getByLabelText('From')
+      const numDaysInput = getByLabelText('Number of working days (optional)')
+      const numOfHrsInput = getByLabelText('Number of hours (optional)')
+      const reasonInput = getByLabelText('Reason for absence')
+      const button = getByRole('button')
+
+      fireEvent.change(fromInput, { target: { value: '2021-11-11' } })
+      fireEvent.change(numDaysInput, { target: { value: '3' } })
+      fireEvent.change(numOfHrsInput, { target: { value: '1' } })
+      fireEvent.change(reasonInput, { target: { value: 'Need a break!' } })
+      fireEvent.click(button)
+
+      expect(mockPostHolidayRequest).toHaveBeenCalledWith({
+        authedUser: '12345',
+        fromDate: new Date('2021-11-11'),
+        reason: 'Need a break!',
+        totalDays: 3,
+        totalHours: 1,
+      })
+    })
+
+    it('redirects the user to the dashboard when a successful holiday request has been made', async () => {
+      const { getByLabelText, getByRole } = render(<HolidayRequest />)
+      const fromInput = getByLabelText('From')
+      const numDaysInput = getByLabelText('Number of working days (optional)')
+      const numOfHrsInput = getByLabelText('Number of hours (optional)')
+      const reasonInput = getByLabelText('Reason for absence')
+      const button = getByRole('button')
+
+      fireEvent.change(fromInput, { target: { value: '2021-11-11' } })
+      fireEvent.change(numDaysInput, { target: { value: '3' } })
+      fireEvent.change(numOfHrsInput, { target: { value: '1' } })
+      fireEvent.change(reasonInput, { target: { value: 'Need a break!' } })
+      fireEvent.click(button)
+
+      await waitFor(() => expect(mockedRouterReplace).toBeCalledWith('./dashboard'))
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,6 +3488,11 @@ date-and-time@^2.0.0:
   resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-2.0.1.tgz#bc8b72704980e8a0979bb186118d30d02059ef04"
   integrity sha512-O7Xe5dLaqvY/aF/MFWArsAM1J4j7w1CSZlPCX9uHgmb+6SbkPd8Q4YOvfvH/cZGvFlJFfHOZKxQtmMUOoZhc/w==
 
+date-fns@^2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"
+  integrity sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==
+
 debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Description
===
This work allows a logged in user to make a holiday request.
On a successful POST to firestore, the user will then be redirected to the dashboard to see all requests made.

### NOTES
Dashboard is still to be built to show holiday requests